### PR TITLE
Change `author` key in quarto yaml to be `student`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ layout: fancy, oneside, masters
 # degree: Bachelors of Science with University Honors
 ```
 
-The next set of options concerns the committee and department for your thesis.
+The next set of options concerns the committee and department for your thesis. Note that the `author` fields for the article YAML are not used for putting the student name in. This allows you to have the authorship of your paper be different from your committee.
+
 ```yaml
+student: Cosmo Cougar
 department: Civil and Construction Engineering
 # list your chair and any other members of your committee
 chair: Norman D. Smith

--- a/_extensions/byu-thesis/byuthesis.tex
+++ b/_extensions/byu-thesis/byuthesis.tex
@@ -5,7 +5,8 @@
 $pandoc.tex()$
 
 \title{$title$}
-\author{$author$}
+\author{$student$}
+%\author{$author$}
 
 % On the custom title page, use the same title, but format as you like
 \customtitle{$if(customtitle)$$customtitle$$else$$title$$endif$}

--- a/_quarto.yaml
+++ b/_quarto.yaml
@@ -35,6 +35,7 @@ layout: fancy, oneside, masters
 # the \degree command: \degree{Bachelors of Science}
 # degree: Bachelors of Science with University Honors
 department: Civil and Construction Engineering
+student: Cosmo Cougar
 # list your chair and any other members of your committee
 chair: Norman D. Smith
 committee:

--- a/_quarto.yaml
+++ b/_quarto.yaml
@@ -3,7 +3,6 @@ project:
 
 book:
   title: "An example thesis"
-  author: "Cosmo Cougar"
   date: "2022"
   chapters:
     - index.qmd


### PR DESCRIPTION
This lets you have an `author` tag like normal (including multiple authors) for rendering to other formats, and then a `student` tag with just the student (no additional authors) for rendering to byuthesis